### PR TITLE
Improve setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# powerbi-token-server
-powerbi-token-server
+# Power BI Token Server
+
+This Flask application returns an embed token for a Power BI report so it can be displayed on a website. It exposes a single endpoint `/getEmbedToken` which expects `reportId`, `groupId` and `datasetId` query parameters.
+
+## Requirements
+
+* Python 3.10 or newer
+* The packages listed in `requirements.txt`
+
+It is recommended to create a virtual environment before installing dependencies.
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Configuration
+
+Update `TENANT_ID`, `CLIENT_ID` and the allowed CORS domain at the top of `app.py` if needed. The application expects a `CLIENT_SECRET` environment variable. Set it in your shell before starting the app:
+
+```bash
+export CLIENT_SECRET="<your AAD app client secret>"
+```
+
+## Running the server
+
+After installing the dependencies and setting `CLIENT_SECRET`, start the Flask app:
+
+```bash
+python app.py
+```
+
+The server will listen on port `5000` by default. The embed token endpoint will be available at `http://localhost:5000/getEmbedToken`.
+
+## Embedding in WordPress
+
+Include `wp-powerbi-embed.js` on your WordPress page and define the Power BI configuration before loading the script:
+
+```html
+<div id="reportContainer" style="height:600px;"></div>
+<script>
+  window.PowerBIEmbedConfig = {
+    reportId: "<report-id>",
+    groupId: "<workspace-id>",
+    datasetId: "<dataset-id>"
+  };
+</script>
+<script src="/path/to/wp-powerbi-embed.js"></script>
+```
+
+The script fetches an embed token from your Flask server and renders the report using the Power BI client library.


### PR DESCRIPTION
## Summary
- document Python version and package installation
- explain how to set `CLIENT_SECRET`
- add examples to run the server and embed in WordPress

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6840f070b6d0832f90e6861466f2c379