### PR TITLE
Add responsive styles for PowerBI embed

### DIFF
--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -5,6 +5,19 @@ window.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
+  // Inject minimal styles for embedding
+  const styleTag = document.createElement('style');
+  styleTag.textContent = `
+    footer, .site-footer { display: none !important; }
+    @media (max-width: 767px) {
+      #reportContainer {
+        position: relative;
+        width: 100%;
+      }
+    }
+  `;
+  document.head.appendChild(styleTag);
+
   const configData = window.PowerBIEmbedConfig || {};
   const { reportId, groupId, datasetId } = configData;
 


### PR DESCRIPTION
## Summary
- inject mobile CSS for PowerBI embed so the report container uses relative positioning and full width on small screens
- always hide WordPress footers

## Testing
- `python -m py_compile app.py`
- `node -e "require('./wp-powerbi-embed.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6840f0719d24832f886a3f29f7102a87