### PR TITLE
Add viewport meta to embed snippet

### DIFF
--- a/embed-html
+++ b/embed-html
@@ -1,3 +1,4 @@
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   html, body {
     margin: 0;


### PR DESCRIPTION
## Summary
- set a viewport meta tag at the top of `embed-html` so mobile browsers size the page correctly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840fa91de28832fa6cb14356ae9f438