### PR TITLE
Add pytest tests and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,23 @@
+name: Python Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -q

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==2.2.5
 flask-cors==3.0.10
 msal==1.25.0
 requests==2.31.0
+pytest==7.4.0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,49 @@
+import json
+import types
+import builtins
+import pytest
+
+import app
+
+@pytest.fixture
+def client(monkeypatch):
+    # Ensure CLIENT_SECRET is set
+    monkeypatch.setattr(app, "CLIENT_SECRET", "dummy-secret")
+
+    # Create fake msal client
+    class FakeMSALApp:
+        def __init__(self, *args, **kwargs):
+            pass
+        def acquire_token_for_client(self, scopes=None):
+            return {"access_token": "aad-token"}
+
+    # Patch msal ConfidentialClientApplication
+    monkeypatch.setattr(app.msal, "ConfidentialClientApplication", lambda *a, **k: FakeMSALApp())
+
+    # Patch requests.post to return fake token
+    class FakeResponse:
+        status_code = 200
+        def json(self):
+            return {"token": "embed-token"}
+    monkeypatch.setattr(app.requests, "post", lambda *a, **k: FakeResponse())
+
+    with app.app.test_client() as c:
+        yield c
+
+def test_get_embed_token_success(client):
+    response = client.get("/getEmbedToken", query_string={
+        "reportId": "r1",
+        "groupId": "g1",
+        "datasetId": "d1"
+    })
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["token"] == "embed-token"
+    assert data["embedUrl"].endswith("reportId=r1&groupId=g1")
+
+
+def test_get_embed_token_missing_params(client):
+    response = client.get("/getEmbedToken", query_string={"reportId": "r1"})
+    assert response.status_code == 400
+    data = response.get_json()
+    assert "error" in data


### PR DESCRIPTION
## Summary
- add pytest to requirements
- create tests for `/getEmbedToken`
- run tests in GitHub Actions

## Testing
- `pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6841014c9750832fa4639f9ca6103d13