### PR TITLE
Separate Power BI config from embed snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,18 +35,17 @@ The server will listen on port `5000` by default. The embed token endpoint will 
 
 ## Embedding in WordPress
 
-Include `wp-powerbi-embed.js` on your WordPress page and define the Power BI configuration before loading the script:
+Include `wp-powerbi-embed.js` on your WordPress page. Define the Power BI
+configuration in a separate script before loading the embed snippet:
 
 ```html
+<script src="/path/to/wp-powerbi-config.js"></script>
 <div id="reportContainer" style="height:600px;"></div>
-<script>
-  window.PowerBIEmbedConfig = {
-    reportId: "<report-id>",
-    groupId: "<workspace-id>",
-    datasetId: "<dataset-id>"
-  };
-</script>
 <script src="/path/to/wp-powerbi-embed.js"></script>
 ```
+
+`wp-powerbi-config.js` should set `window.PowerBIEmbedConfig` with your report,
+workspace and dataset IDs. See the provided `wp-powerbi-config.js` file for an
+example.
 
 The script fetches an embed token from your Flask server and renders the report using the Power BI client library.

--- a/embed-html
+++ b/embed-html
@@ -57,14 +57,11 @@
   }
 </style>
 
-<!-- 1. Declare config up front -->
-<script>
-  window.PowerBIEmbedConfig = {
-    reportId: "a6479e28-0ed5-4515-90ec-af205f635699",
-    groupId: "5c32a84f-0b3d-406c-9097-4930093e3005",
-    datasetId: "340c9e95-0459-4b8b-9e36-9c968643d777"
-  };
-</script>
+<!-- 1. Load configuration -->
+<!--
+  Include a script that defines `window.PowerBIEmbedConfig` before this file
+  is loaded. See `wp-powerbi-config.js` for an example configuration.
+-->
 
 <!-- 2. Embed container -->
 <div id="reportWrapper">

--- a/wp-powerbi-config.js
+++ b/wp-powerbi-config.js
@@ -1,0 +1,7 @@
+// Example Power BI configuration
+// Replace the IDs below with your actual report, workspace and dataset values.
+window.PowerBIEmbedConfig = {
+  reportId: "a6479e28-0ed5-4515-90ec-af205f635699",
+  groupId: "5c32a84f-0b3d-406c-9097-4930093e3005",
+  datasetId: "340c9e95-0459-4b8b-9e36-9c968643d777"
+};


### PR DESCRIPTION
## Summary
- let `window.PowerBIEmbedConfig` live in its own `wp-powerbi-config.js`
- update `embed-html` to assume the config script is loaded separately
- document the new approach in the README

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68419ac83198832f9c7c32e100c4b67b