### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ This Flask application returns an embed token for a Power BI report so it can be
 * The packages listed in `requirements.txt`
 
 It is recommended to create a virtual environment before installing dependencies.
+Make sure to specify the Python version when creating the environment:
 
 ```bash
-python -m venv venv
+# Windows
+py -3.10 -m venv venv
+# macOS/Linux
+python3.10 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
 ```


### PR DESCRIPTION
## Summary
- mention using a specific Python version when creating the venv

## Testing
- `PYTHONPATH=. pytest -q` *(fails: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6841a54518d8832f9316394679c5f438