### PR TITLE
Enable container based config for PowerBI embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,15 @@ The server will listen on port `5000` by default. The embed token endpoint will 
 
 ## Embedding in WordPress
 
-Include `wp-powerbi-embed.js` on your WordPress page and define the Power BI configuration before loading the script:
+Include `wp-powerbi-embed.js` on your WordPress page and provide the report information using attributes (or by defining `window.PowerBIEmbedConfig` before the script loads):
 
 ```html
-<div id="reportContainer" style="height:600px;"></div>
-<script>
-  window.PowerBIEmbedConfig = {
-    reportId: "<report-id>",
-    groupId: "<workspace-id>",
-    datasetId: "<dataset-id>"
-  };
-</script>
+<div id="reportContainer"
+     data-report-id="<report-id>"
+     data-group-id="<workspace-id>"
+     data-dataset-id="<dataset-id>">
+  Loading Power BI...
+</div>
 <script src="/path/to/wp-powerbi-embed.js"></script>
 ```
 

--- a/embed-html
+++ b/embed-html
@@ -57,18 +57,14 @@
   }
 </style>
 
-<!-- 1. Declare config up front -->
-<script>
-  window.PowerBIEmbedConfig = {
-    reportId: "a6479e28-0ed5-4515-90ec-af205f635699",
-    groupId: "5c32a84f-0b3d-406c-9097-4930093e3005",
-    datasetId: "340c9e95-0459-4b8b-9e36-9c968643d777"
-  };
-</script>
-
-<!-- 2. Embed container -->
+<!-- 1. Example container with embed attributes -->
 <div id="reportWrapper">
-  <div id="reportContainer">Loading Power BI...</div>
+  <div id="reportContainer"
+       data-report-id="a6479e28-0ed5-4515-90ec-af205f635699"
+       data-group-id="5c32a84f-0b3d-406c-9097-4930093e3005"
+       data-dataset-id="340c9e95-0459-4b8b-9e36-9c968643d777">
+    Loading Power BI...
+  </div>
 </div>
 
 <!-- 3. Embed logic -->
@@ -77,8 +73,12 @@
   sdkScript.src = "https://cdn.jsdelivr.net/npm/powerbi-client@2.21.0/dist/powerbi.min.js";
 
   sdkScript.onload = () => {
-    const configData = window.PowerBIEmbedConfig;
     const container = document.getElementById("reportContainer");
+    const configData = window.PowerBIEmbedConfig || {
+      reportId: container.dataset.reportId,
+      groupId: container.dataset.groupId,
+      datasetId: container.dataset.datasetId,
+    };
 
     const url = `https://powerbi-token-server.onrender.com/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
 

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -18,7 +18,11 @@ window.addEventListener('DOMContentLoaded', () => {
   `;
   document.head.appendChild(styleTag);
 
-  const configData = window.PowerBIEmbedConfig || {};
+  const configData = window.PowerBIEmbedConfig || {
+    reportId: container.dataset.reportId,
+    groupId: container.dataset.groupId,
+    datasetId: container.dataset.datasetId,
+  };
   const { reportId, groupId, datasetId } = configData;
 
   console.log("Embed Params:", { reportId, groupId, datasetId });


### PR DESCRIPTION
## Summary
- support reading Power BI embed parameters from `#reportContainer` attributes
- document container attributes in README example
- update example `embed-html` to show usage and load config from attributes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_6841aa44a814832f867a39dd509cfe3a