### PR TITLE
Add standalone CSS for embeds

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ The server will listen on port `5000` by default. The embed token endpoint will 
 
 ## Embedding in WordPress
 
-Include `wp-powerbi-embed.js` on your WordPress page and provide the report information using attributes (or by defining `window.PowerBIEmbedConfig` before the script loads):
+Include `powerbi-embed.css` and `wp-powerbi-embed.js` on your WordPress page and provide the report information using attributes (or by defining `window.PowerBIEmbedConfig` before the script loads):
 
 ```html
+<link rel="stylesheet" href="/path/to/powerbi-embed.css">
 <div id="reportContainer"
      data-report-id="<report-id>"
      data-group-id="<workspace-id>"

--- a/powerbi-embed.css
+++ b/powerbi-embed.css
@@ -1,0 +1,55 @@
+  html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
+  }
+
+  header, .site-header {
+    z-index: 1100;
+  }
+
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    position: fixed;
+    top: 95px;
+    left: 0;
+    width: 100vw !important;
+    min-width: 1024px !important;
+    height: calc(100vh - 95px) !important;
+    max-height: calc(100vh - 95px) !important;
+    max-width: 100vw !important;
+    margin: 0;
+    padding: 0;
+    border: none;
+    overflow: hidden;
+    z-index: 1000;
+  }
+
+  @media (max-width: 767px) {
+    #reportWrapper,
+    #reportContainer,
+    #reportContainer iframe {
+      min-width: 100vw !important;
+      overflow: auto !important;
+    }
+    #reportContainer,
+    #reportContainer iframe {
+      height: calc(100dvh - 95px) !important;
+      overflow-y: auto !important;
+    }
+  }
+
+  footer, .site-footer {
+    display: none !important;
+  }
+
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    top: 132px;
+    height: calc(100vh - 132px) !important;
+    max-height: calc(100vh - 132px) !important;
+  }

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -5,18 +5,17 @@ window.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  // Inject minimal styles for embedding
-  const styleTag = document.createElement('style');
-  styleTag.textContent = `
-    footer, .site-footer { display: none !important; }
-    @media (max-width: 767px) {
-      #reportContainer {
-        position: relative;
-        width: 100%;
-      }
-    }
-  `;
-  document.head.appendChild(styleTag);
+  // Ensure embed stylesheet is present
+  const cssId = 'powerbi-embed-styles';
+  if (!document.getElementById(cssId)) {
+    const link = document.createElement('link');
+    link.id = cssId;
+    link.rel = 'stylesheet';
+    const currentScript = document.currentScript;
+    const base = currentScript ? currentScript.src.split('/').slice(0, -1).join('/') + '/' : '';
+    link.href = base + 'powerbi-embed.css';
+    document.head.appendChild(link);
+  }
 
   const configData = window.PowerBIEmbedConfig || {
     reportId: container.dataset.reportId,


### PR DESCRIPTION
## Summary
- add `powerbi-embed.css` for Power BI iframe styling
- auto-load the CSS from `wp-powerbi-embed.js`
- document CSS inclusion in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6841fdaeced4832fa5d3a78f5313129e