### PR TITLE
Adjust mobile CSS for long Power BI canvases

### DIFF
--- a/embed-html
+++ b/embed-html
@@ -31,16 +31,24 @@
   }
 
   @media (max-width: 767px) {
+    html,
+    body {
+      overflow: auto;
+    }
+
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      min-width: 100vw !important;
-      overflow: auto !important;
-    }
-    #reportContainer,
-    #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      overflow-y: auto !important;
+      position: static;
+      top: auto;
+      left: auto;
+      width: 100% !important;
+      min-width: 0 !important;
+      height: auto !important;
+      min-height: 100svh;
+      max-height: none !important;
+      max-width: 100% !important;
+      overflow: visible !important;
     }
   }
 

--- a/powerbi-embed.css
+++ b/powerbi-embed.css
@@ -29,16 +29,24 @@
   }
 
   @media (max-width: 767px) {
+    html,
+    body {
+      overflow: auto;
+    }
+
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      min-width: 100vw !important;
-      overflow: auto !important;
-    }
-    #reportContainer,
-    #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      overflow-y: auto !important;
+      position: static;
+      top: auto;
+      left: auto;
+      width: 100% !important;
+      min-width: 0 !important;
+      height: auto !important;
+      min-height: 100svh;
+      max-height: none !important;
+      max-width: 100% !important;
+      overflow: visible !important;
     }
   }
 


### PR DESCRIPTION
## Summary
- relax overflow restrictions for long canvases on mobile
- remove fixed positioning and enforce regular flow in small screens

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68438bb3bdf8832f8387c062b6742ee1