### PR TITLE
Add local testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Include `powerbi-embed.css` and `wp-powerbi-embed.js` on your WordPress page and
 ```
 
 The script fetches an embed token from your Flask server and renders the report using the Power BI client library.
+
+## Testing locally
+
+The `embed-html` file demonstrates the Power BI container, required CSS and the embed logic in a single document. Update the `data-report-id`, `data-group-id` and `data-dataset-id` attributes with your own IDs. When testing against a local token server you can also set a `data-server-url` attribute (or define `window.PowerBIEmbedConfig.serverUrl` before the script loads) to override the token endpoint.


### PR DESCRIPTION
## Summary
- document using the embed-html file
- explain how to set IDs and an optional server URL when testing locally

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68439e59a94c832fa98fd9f9874049d1