### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+__pycache__/
+.pytest_cache/
+venv/
+.env
+.venv/
+*.py[cod]
+*.egg-info/
+build/
+dist/
+.eggs/
+.DS_Store
+.idea/
+.vscode/
+


### PR DESCRIPTION
## Summary
- add .gitignore with common Python cache and virtual environment directories

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684432133790832f8849a36da3c322ab