### PR TITLE
Allow overriding token server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,21 +48,22 @@ The server will listen on port `5000` by default. The embed token endpoint will 
 
 ## Embedding in WordPress
 
-Include `powerbi-embed.css` and `wp-powerbi-embed.js` on your WordPress page and provide the report information using attributes (or by defining `window.PowerBIEmbedConfig` before the script loads):
+Include `powerbi-embed.css` and `wp-powerbi-embed.js` on your WordPress page and provide the report information using attributes (or by defining `window.PowerBIEmbedConfig` before the script loads). The script defaults to the hosted token service at `https://powerbi-token-server.onrender.com`, but you can override this URL if needed:
 
 ```html
 <link rel="stylesheet" href="/path/to/powerbi-embed.css">
 <div id="reportContainer"
      data-report-id="<report-id>"
      data-group-id="<workspace-id>"
-     data-dataset-id="<dataset-id>">
+     data-dataset-id="<dataset-id>"
+     data-server-url="https://powerbi-token-server.onrender.com">
   Loading Power BI...
 </div>
 <script src="/path/to/wp-powerbi-embed.js"></script>
 ```
 
-The script fetches an embed token from your Flask server and renders the report using the Power BI client library.
+The script fetches an embed token from your Flask server and renders the report using the Power BI client library. Specify a different server with the `data-server-url` attribute or by setting `window.PowerBIEmbedConfig.serverUrl` before loading the script.
 
 ### Testing locally
 
-Copy the `embed-html` file anywhere on your system to try the embed code outside of WordPress. Update its `data-report-id`, `data-group-id` and `data-dataset-id` attributes with your own IDs. When testing against a local token server, set a `data-server-url` attribute (or define `window.PowerBIEmbedConfig.serverUrl` before the script loads) to override the default token endpoint.
+Copy the `embed-html` file anywhere on your system to try the embed code outside of WordPress. Update its `data-report-id`, `data-group-id` and `data-dataset-id` attributes with your own IDs. When testing against a local token server, set a `data-server-url` attribute (or define `window.PowerBIEmbedConfig.serverUrl` before the script loads) to override the default token endpoint (which defaults to `https://powerbi-token-server.onrender.com`).

--- a/embed-html
+++ b/embed-html
@@ -77,13 +77,14 @@
 
   sdkScript.onload = () => {
     const container = document.getElementById("reportContainer");
-    const configData = window.PowerBIEmbedConfig || {
-      reportId: container.dataset.reportId,
-      groupId: container.dataset.groupId,
-      datasetId: container.dataset.datasetId,
-    };
+    const configData = window.PowerBIEmbedConfig || {};
+    configData.reportId = configData.reportId || container.dataset.reportId;
+    configData.groupId = configData.groupId || container.dataset.groupId;
+    configData.datasetId = configData.datasetId || container.dataset.datasetId;
+    configData.serverUrl = (configData.serverUrl || container.dataset.serverUrl ||
+      "https://powerbi-token-server.onrender.com").replace(/\/?$/, "");
 
-    const url = `https://powerbi-token-server.onrender.com/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
+    const url = `${configData.serverUrl}/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
 
     fetch(url)
       .then(res => res.json())

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -17,14 +17,14 @@ window.addEventListener('DOMContentLoaded', () => {
     document.head.appendChild(link);
   }
 
-  const configData = window.PowerBIEmbedConfig || {
-    reportId: container.dataset.reportId,
-    groupId: container.dataset.groupId,
-    datasetId: container.dataset.datasetId,
-  };
-  const { reportId, groupId, datasetId } = configData;
+  const configData = window.PowerBIEmbedConfig || {};
+  const reportId = configData.reportId || container.dataset.reportId;
+  const groupId = configData.groupId || container.dataset.groupId;
+  const datasetId = configData.datasetId || container.dataset.datasetId;
+  const serverUrl = (configData.serverUrl || container.dataset.serverUrl ||
+    'https://powerbi-token-server.onrender.com').replace(/\/?$/, '');
 
-  console.log("Embed Params:", { reportId, groupId, datasetId });
+  console.log("Embed Params:", { reportId, groupId, datasetId, serverUrl });
 
   if (!reportId || !groupId || !datasetId) {
     container.innerText = "Missing embed configuration data.";
@@ -36,7 +36,7 @@ window.addEventListener('DOMContentLoaded', () => {
   sdkScript.src = 'https://cdn.jsdelivr.net/npm/powerbi-client@2.21.0/dist/powerbi.min.js';
 
   sdkScript.onload = () => {
-    const url = `https://powerbi-token-server.onrender.com/getEmbedToken?reportId=${reportId}&groupId=${groupId}&datasetId=${datasetId}`;
+    const url = `${serverUrl}/getEmbedToken?reportId=${reportId}&groupId=${groupId}&datasetId=${datasetId}`;
     console.log("Fetching token from:", url);
 
     fetch(url)


### PR DESCRIPTION
## Summary
- support `data-server-url` and `window.PowerBIEmbedConfig.serverUrl` in embed scripts
- set default token server URL to current onrender.com instance
- document the option in `README`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684433943b94832f8c2dd92930f515f0