### PR TITLE
Add serverUrl override support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Include `powerbi-embed.css` and `wp-powerbi-embed.js` on your WordPress page and
 <div id="reportContainer"
      data-report-id="<report-id>"
      data-group-id="<workspace-id>"
-     data-dataset-id="<dataset-id>">
+     data-dataset-id="<dataset-id>"
+     data-server-url="http://localhost:5000"><!-- optional override -->
   Loading Power BI...
 </div>
 <script src="/path/to/wp-powerbi-embed.js"></script>
@@ -65,7 +66,7 @@ The script fetches an embed token from your Flask server and renders the report 
 
 ### Testing locally
 
-Copy the `embed-html` file anywhere on your system to try the embed code outside of WordPress. Update its `data-report-id`, `data-group-id` and `data-dataset-id` attributes with your own IDs. When testing against a local token server, set a `data-server-url` attribute (or define `window.PowerBIEmbedConfig.serverUrl` before the script loads) to override the default token endpoint.
+Copy the `embed-html` file anywhere on your system to try the embed code outside of WordPress. Update its `data-report-id`, `data-group-id` and `data-dataset-id` attributes with your own IDs. When testing against a local token server, set a `data-server-url` attribute (or define `window.PowerBIEmbedConfig.serverUrl` before the script loads) to override the default token endpoint (which is `https://powerbi-token-server.onrender.com`).
 
 ## License
 

--- a/embed-html
+++ b/embed-html
@@ -62,11 +62,12 @@
 </style>
 
 <!-- 1. Example container with embed attributes -->
-<div id="reportWrapper">
-  <div id="reportContainer"
-       data-report-id="4161a7fc-29dc-417f-9e37-1a2c588d7d65"
-       data-group-id="5c32a84f-0b3d-406c-9097-4930093e3005"
-       data-dataset-id="2fec5575-9628-4a8b-a99c-c689acb7efd">
+  <div id="reportWrapper">
+    <div id="reportContainer"
+         data-report-id="4161a7fc-29dc-417f-9e37-1a2c588d7d65"
+         data-group-id="5c32a84f-0b3d-406c-9097-4930093e3005"
+         data-dataset-id="2fec5575-9628-4a8b-a99c-c689acb7efd"
+         data-server-url="http://localhost:5000">
     Loading Power BI...
   </div>
 </div>
@@ -83,8 +84,10 @@
       groupId: container.dataset.groupId,
       datasetId: container.dataset.datasetId,
     };
-
-    const url = `https://powerbi-token-server.onrender.com/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
+    const base = (window.PowerBIEmbedConfig && window.PowerBIEmbedConfig.serverUrl) ||
+                 container.dataset.serverUrl ||
+                 "https://powerbi-token-server.onrender.com";
+    const url = `${base.replace(/\/+$/, '')}/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
 
     fetch(url)
       .then(res => res.json())

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -23,6 +23,10 @@ window.addEventListener('DOMContentLoaded', () => {
     datasetId: container.dataset.datasetId,
   };
   const { reportId, groupId, datasetId } = configData;
+  const serverUrl =
+    (window.PowerBIEmbedConfig && window.PowerBIEmbedConfig.serverUrl) ||
+    container.dataset.serverUrl ||
+    "https://powerbi-token-server.onrender.com";
 
   console.log("Embed Params:", { reportId, groupId, datasetId });
 
@@ -36,7 +40,8 @@ window.addEventListener('DOMContentLoaded', () => {
   sdkScript.src = 'https://cdn.jsdelivr.net/npm/powerbi-client@2.21.0/dist/powerbi.min.js';
 
   sdkScript.onload = () => {
-    const url = `https://powerbi-token-server.onrender.com/getEmbedToken?reportId=${reportId}&groupId=${groupId}&datasetId=${datasetId}`;
+    const base = serverUrl.replace(/\/+$/, "");
+    const url = `${base}/getEmbedToken?reportId=${reportId}&groupId=${groupId}&datasetId=${datasetId}`;
     console.log("Fetching token from:", url);
 
     fetch(url)


### PR DESCRIPTION
## Summary
- allow overriding token server in `wp-powerbi-embed.js`
- show server override in README
- update example HTML to demonstrate custom server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684440629378832f9b399311d1d96798