### PR TITLE
Fix mobile layout height

### DIFF
--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -3,9 +3,9 @@
   html, body {
     margin: 0;
     padding: 0;
-    height: 100%;
+    min-height: 100svh;
     width: 100%;
-    overflow: hidden;
+    overflow: auto;
   }
 
   header, .site-header {
@@ -31,18 +31,12 @@
   }
 
   @media (max-width: 767px) {
-    html,
-    body {
-      overflow: auto;
-    }
-
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
       position: static;
       width: 100%;
-      height: auto;
-      min-height: 100svh;
+      height: calc(100svh - 95px);
       overflow: visible;
     }
   }


### PR DESCRIPTION
## Summary
- fix mobile layout height by using viewport height minus header

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68447c72bb54832fbfdcd896420b3b2b