### PR TITLE
Fix dynamic viewport height in test snippet

### DIFF
--- a/embed-html-render-2
+++ b/embed-html-render-2
@@ -52,14 +52,22 @@ index 0000000000000000000000000000000000000000..ea3ac02d48f8dbf5be00b3347c964cfc
 +    left: 0;
 +    width: 100vw !important;
 +    min-width: 1024px !important;
-+    height: calc(100vh - 95px) !important;
-+    max-height: calc(100vh - 95px) !important;
++    height: calc(100svh - 95px) !important;
++    max-height: calc(100svh - 95px) !important;
 +    max-width: 100vw !important;
 +    margin: 0;
 +    padding: 0;
 +    border: none;
 +    overflow: hidden;
 +    z-index: 1000;
++  }
++  @supports (height: 100dvh) {
++    #reportWrapper,
++    #reportContainer,
++    #reportContainer iframe {
++      height: calc(100dvh - 95px) !important;
++      max-height: calc(100dvh - 95px) !important;
++    }
 +  }
 +
 +  @media (max-width: 767px) {


### PR DESCRIPTION
## Summary
- adjust test snippet `embed-html-render-2` to use `100svh` and `100dvh`
  so mobile navigation isn't clipped

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684494603c8c832f9af3870193962fd2