### PR TITLE
Use CSS variable for header height

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Include `wp-powerbi-embed.js` on your WordPress page and provide the report info
 <script src="/path/to/wp-powerbi-embed.js"></script>
 ```
 
+The stylesheet defines a `--header-height` CSS custom property with a default
+value of `95px`. Override this variable in your own CSS if your theme's header
+height differs:
+
+```css
+:root {
+  --header-height: 80px;
+}
+```
+
 By default the script contacts `https://powerbi-token-server.onrender.com` for tokens.
 To use a different endpoint, provide a `data-server-url` attribute or define
 `window.PowerBIEmbedConfig.serverUrl` before the script loads:

--- a/embed-css-call-from-astra.css
+++ b/embed-css-call-from-astra.css
@@ -1,3 +1,7 @@
+  :root {
+    --header-height: 95px;
+  }
+
   html, body {
     margin: 0;
     padding: 0;
@@ -14,11 +18,11 @@
   #reportContainer,
   #reportContainer iframe {
     position: fixed;
-    top: 95px;
+    top: var(--header-height);
     left: 0;
     width: 100vw !important;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
+    height: calc(100vh - var(--header-height)) !important;
+    max-height: calc(100vh - var(--header-height)) !important;
     max-width: 100vw !important;
     margin: 0;
     padding: 0;
@@ -31,8 +35,8 @@
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
   }
 
@@ -46,15 +50,15 @@
   #reportWrapper {
     position: static;
     width: 100%;
-    height: calc(100vh - 95px);
+    height: calc(100vh - var(--header-height));
     overflow: auto;
   }
 
   #reportContainer {
     position: static;
     width: 100%;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
+    height: calc(100vh - var(--header-height)) !important;
+    max-height: calc(100vh - var(--header-height)) !important;
     overflow: auto;
   }
 
@@ -82,8 +86,8 @@
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
 
     body.admin-bar #reportWrapper,

--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -1,5 +1,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
+  :root {
+    --header-height: 95px;
+  }
+
   html, body {
     margin: 0;
     padding: 0;
@@ -16,11 +20,11 @@
   #reportContainer,
   #reportContainer iframe {
     position: fixed;
-    top: 95px;
+    top: var(--header-height);
     left: 0;
     width: 100vw !important;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
+    height: calc(100vh - var(--header-height)) !important;
+    max-height: calc(100vh - var(--header-height)) !important;
     max-width: 100vw !important;
     margin: 0;
     padding: 0;
@@ -36,7 +40,7 @@
     #reportContainer iframe {
       position: static;
       width: 100%;
-      height: calc(100vh - 95px);
+      height: calc(100vh - var(--header-height));
       overflow: auto;
     }
   }
@@ -57,8 +61,8 @@
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
 
     body.admin-bar #reportWrapper,

--- a/wp-embedded-html.html
+++ b/wp-embedded-html.html
@@ -1,5 +1,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
+  :root {
+    --header-height: 95px;
+  }
+
   html, body {
     margin: 0;
     padding: 0;
@@ -16,11 +20,11 @@
   #reportContainer,
   #reportContainer iframe {
     position: fixed;
-    top: 95px;
+    top: var(--header-height);
     left: 0;
     width: 100vw !important;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
+    height: calc(100vh - var(--header-height)) !important;
+    max-height: calc(100vh - var(--header-height)) !important;
     max-width: 100vw !important;
     margin: 0;
     padding: 0;
@@ -41,7 +45,7 @@
     #reportContainer iframe {
       position: static;
       width: 100%;
-      height: calc(100vh - 95px);
+      height: calc(100vh - var(--header-height));
       overflow: auto;
     }
   }
@@ -62,8 +66,8 @@
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
 
     body.admin-bar #reportWrapper,


### PR DESCRIPTION
## Summary
- add `--header-height` CSS variable and use throughout snippets
- update README with instructions on overriding the variable

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6844c22f91c4832f9061166279d61fc3