### PR TITLE
Fix mobile footer gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Include `wp-powerbi-embed.js` on your WordPress page and provide the report info
 <script src="/path/to/wp-powerbi-embed.js"></script>
 ```
 
+The stylesheet defines a `--header-height` CSS custom property with a default
+value of `95px`. Override this variable in your own CSS if your theme's header
+height differs:
+
+```css
+:root {
+  --header-height: 80px;
+}
+```
+
 By default the script contacts `https://powerbi-token-server.onrender.com` for tokens.
 To use a different endpoint, provide a `data-server-url` attribute or define
 `window.PowerBIEmbedConfig.serverUrl` before the script loads:

--- a/embed-css-call-from-astra.css
+++ b/embed-css-call-from-astra.css
@@ -1,3 +1,7 @@
+  :root {
+    --header-height: 95px;
+  }
+
   html, body {
     margin: 0;
     padding: 0;
@@ -14,7 +18,7 @@
   #reportContainer,
   #reportContainer iframe {
     position: fixed;
-    top: 95px;
+    top: var(--header-height);
     bottom: 0;
     left: 0;
     width: 100vw !important;
@@ -30,7 +34,7 @@
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100vh - 95px);
+    height: calc(100vh - var(--header-height));
   }
 
   body.admin-bar #reportWrapper,
@@ -44,8 +48,8 @@
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
 
     body.admin-bar #reportWrapper,
@@ -66,15 +70,15 @@
   #reportWrapper {
     position: static;
     width: 100%;
-    height: calc(100vh - 95px);
+    height: calc(100vh - var(--header-height));
     overflow: auto;
   }
 
   #reportContainer {
     position: static;
     width: 100%;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
+    height: calc(100vh - var(--header-height)) !important;
+    max-height: calc(100vh - var(--header-height)) !important;
     overflow: auto;
   }
 

--- a/embed-css-call-from-astra.css
+++ b/embed-css-call-from-astra.css
@@ -15,10 +15,9 @@
   #reportContainer iframe {
     position: fixed;
     top: 95px;
+    bottom: 0;
     left: 0;
     width: 100vw !important;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
     max-width: 100vw !important;
     margin: 0;
     padding: 0;
@@ -27,12 +26,33 @@
     z-index: 1000;
   }
 
+@supports not (height: 100dvh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100vh - 95px);
+  }
+
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100vh - 132px);
+  }
+}
+
   @supports (height: 100dvh) {
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
       height: calc(100dvh - 95px) !important;
       max-height: calc(100dvh - 95px) !important;
+    }
+
+    body.admin-bar #reportWrapper,
+    body.admin-bar #reportContainer,
+    body.admin-bar #reportContainer iframe {
+      height: calc(100dvh - 132px) !important;
+      max-height: calc(100dvh - 132px) !important;
     }
   }
 
@@ -74,22 +94,5 @@
   body.admin-bar #reportContainer,
   body.admin-bar #reportContainer iframe {
     top: 132px;
-    height: calc(100vh - 132px) !important;
-    max-height: calc(100vh - 132px) !important;
-  }
-
-  @supports (height: 100dvh) {
-    #reportWrapper,
-    #reportContainer,
-    #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
-    }
-
-    body.admin-bar #reportWrapper,
-    body.admin-bar #reportContainer,
-    body.admin-bar #reportContainer iframe {
-      height: calc(100dvh - 132px) !important;
-      max-height: calc(100dvh - 132px) !important;
-    }
+    bottom: 0;
   }

--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -17,10 +17,9 @@
   #reportContainer iframe {
     position: fixed;
     top: 95px;
+    bottom: 0;
     left: 0;
     width: 100vw !important;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
     max-width: 100vw !important;
     margin: 0;
     padding: 0;
@@ -29,6 +28,19 @@
     z-index: 1000;
   }
 
+@supports not (height: 100dvh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100vh - 95px);
+  }
+
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100vh - 132px);
+  }
+}
 
   @media (max-width: 767px) {
     #reportWrapper,
@@ -49,8 +61,7 @@
   body.admin-bar #reportContainer,
   body.admin-bar #reportContainer iframe {
     top: 132px;
-    height: calc(100vh - 132px) !important;
-    max-height: calc(100vh - 132px) !important;
+    bottom: 0;
   }
 
   @supports (height: 100dvh) {

--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -1,5 +1,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
+  :root {
+    --header-height: 95px;
+  }
+
   html, body {
     margin: 0;
     padding: 0;
@@ -16,7 +20,7 @@
   #reportContainer,
   #reportContainer iframe {
     position: fixed;
-    top: 95px;
+    top: var(--header-height);
     bottom: 0;
     left: 0;
     width: 100vw !important;
@@ -32,7 +36,7 @@
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100vh - 95px);
+    height: calc(100vh - var(--header-height));
   }
 
   body.admin-bar #reportWrapper,
@@ -48,7 +52,7 @@
     #reportContainer iframe {
       position: static;
       width: 100%;
-      height: calc(100vh - 95px);
+      height: calc(100vh - var(--header-height));
       overflow: auto;
     }
   }
@@ -68,8 +72,8 @@
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
 
     body.admin-bar #reportWrapper,

--- a/wp-embedded-html.html
+++ b/wp-embedded-html.html
@@ -17,10 +17,9 @@
   #reportContainer iframe {
     position: fixed;
     top: 95px;
+    bottom: 0;
     left: 0;
     width: 100vw !important;
-    height: calc(100vh - 95px) !important;
-    max-height: calc(100vh - 95px) !important;
     max-width: 100vw !important;
     margin: 0;
     padding: 0;
@@ -29,6 +28,19 @@
     z-index: 1000;
   }
 
+@supports not (height: 100dvh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100vh - 95px);
+  }
+
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100vh - 132px);
+  }
+}
 
   @media (max-width: 767px) {
     html,
@@ -54,8 +66,7 @@
   body.admin-bar #reportContainer,
   body.admin-bar #reportContainer iframe {
     top: 132px;
-    height: calc(100vh - 132px) !important;
-    max-height: calc(100vh - 132px) !important;
+    bottom: 0;
   }
 
   @supports (height: 100dvh) {
@@ -83,7 +94,6 @@
     Loading Power BI...
   </div>
 </div>
-
 <script>
   const sdkScript = document.createElement("script");
   sdkScript.src = "https://cdn.jsdelivr.net/npm/powerbi-client@2.21.0/dist/powerbi.min.js";

--- a/wp-embedded-html.html
+++ b/wp-embedded-html.html
@@ -1,5 +1,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
+  :root {
+    --header-height: 95px;
+  }
+
   html, body {
     margin: 0;
     padding: 0;
@@ -16,7 +20,7 @@
   #reportContainer,
   #reportContainer iframe {
     position: fixed;
-    top: 95px;
+    top: var(--header-height);
     bottom: 0;
     left: 0;
     width: 100vw !important;
@@ -32,7 +36,7 @@
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100vh - 95px);
+    height: calc(100vh - var(--header-height));
   }
 
   body.admin-bar #reportWrapper,
@@ -53,7 +57,7 @@
     #reportContainer iframe {
       position: static;
       width: 100%;
-      height: calc(100vh - 95px);
+      height: calc(100vh - var(--header-height));
       overflow: auto;
     }
   }
@@ -73,8 +77,8 @@
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - 95px) !important;
-      max-height: calc(100dvh - 95px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
 
     body.admin-bar #reportWrapper,


### PR DESCRIPTION
## Summary
- adjust layout CSS to rely on `bottom: 0` and dynamic viewport units
- add fallback rules for browsers without `100dvh` support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6844c229ddfc832fae14c2c5d9729988