### PR TITLE
Update header height variable for mobile

### DIFF
--- a/embed-css-call-from-astra.css
+++ b/embed-css-call-from-astra.css
@@ -65,6 +65,10 @@
   }
 
   @media (max-width: 767px) {
+    :root {
+      --header-height: 80px;
+    }
+
     html,
     body {
       overflow: auto;

--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -52,6 +52,10 @@
 }
 
   @media (max-width: 767px) {
+    :root {
+      --header-height: 80px;
+    }
+
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {

--- a/wp-embedded-html.html
+++ b/wp-embedded-html.html
@@ -51,6 +51,10 @@
 }
 
   @media (max-width: 767px) {
+    :root {
+      --header-height: 80px;
+    }
+
     html,
     body {
       overflow: auto;


### PR DESCRIPTION
## Summary
- override `--header-height` for mobile screens in embedded HTML templates
- add the same mobile rule in standalone stylesheet

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6844e6eb98a8832f9279ed0e917404ff