### PR TITLE
Add svh layout handling

### DIFF
--- a/embed-css-call-from-astra.css
+++ b/embed-css-call-from-astra.css
@@ -56,13 +56,14 @@
       max-height: calc(100dvh - var(--header-height)) !important;
     }
 
-    body.admin-bar #reportWrapper,
-    body.admin-bar #reportContainer,
-    body.admin-bar #reportContainer iframe {
-      height: calc(100dvh - 132px) !important;
-      max-height: calc(100dvh - 132px) !important;
-    }
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100dvh - 132px) !important;
+    max-height: calc(100dvh - 132px) !important;
   }
+}
+
 
   @media (max-width: 767px) {
     :root {
@@ -126,3 +127,17 @@
       max-height: calc(100dvh - 132px) !important;
     }
   }
+@supports (height: 100svh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100svh - var(--header-height)) !important;
+    max-height: calc(100svh - var(--header-height)) !important;
+  }
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100svh - 132px) !important;
+    max-height: calc(100svh - 132px) !important;
+  }
+}

--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -51,6 +51,7 @@
   }
 }
 
+
   @media (max-width: 767px) {
     :root {
       --header-height: 80px;
@@ -85,14 +86,37 @@
       max-height: calc(100dvh - var(--header-height)) !important;
     }
 
-    body.admin-bar #reportWrapper,
-    body.admin-bar #reportContainer,
-    body.admin-bar #reportContainer iframe {
-      height: calc(100dvh - 132px) !important;
-      max-height: calc(100dvh - 132px) !important;
-    }
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100dvh - 132px) !important;
+    max-height: calc(100dvh - 132px) !important;
   }
+}
+
+@supports (height: 100svh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100svh - var(--header-height)) !important;
+    max-height: calc(100svh - var(--header-height)) !important;
+  }
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100svh - 132px) !important;
+    max-height: calc(100svh - 132px) !important;
+  }
+}
 </style>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const header = document.querySelector('header');
+    if (header) {
+      document.documentElement.style.setProperty('--header-height', header.offsetHeight + 'px');
+    }
+  });
+</script>
 
 <div id="reportWrapper">
   <div id="reportContainer"

--- a/wp-embedded-html.html
+++ b/wp-embedded-html.html
@@ -89,14 +89,37 @@
       max-height: calc(100dvh - var(--header-height)) !important;
     }
 
-    body.admin-bar #reportWrapper,
-    body.admin-bar #reportContainer,
-    body.admin-bar #reportContainer iframe {
-      height: calc(100dvh - 132px) !important;
-      max-height: calc(100dvh - 132px) !important;
-    }
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100dvh - 132px) !important;
+    max-height: calc(100dvh - 132px) !important;
   }
+}
+
+@supports (height: 100svh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100svh - var(--header-height)) !important;
+    max-height: calc(100svh - var(--header-height)) !important;
+  }
+  body.admin-bar #reportWrapper,
+  body.admin-bar #reportContainer,
+  body.admin-bar #reportContainer iframe {
+    height: calc(100svh - 132px) !important;
+    max-height: calc(100svh - 132px) !important;
+  }
+}
 </style>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const header = document.querySelector('header');
+    if (header) {
+      document.documentElement.style.setProperty('--header-height', header.offsetHeight + 'px');
+    }
+  });
+</script>
 
 <div id="reportWrapper">
   <div id="reportContainer"


### PR DESCRIPTION
## Summary
- support svh units in embed layout CSS and HTML
- dynamically set `--header-height` with header measurement

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6844f0d3afb0832fba721044d7a50cbb