### PR TITLE
Fix supports blocks for desktop

### DIFF
--- a/static/embed.css
+++ b/static/embed.css
@@ -114,32 +114,35 @@
     max-height: calc(100vh - 132px) !important;
   }
 
-  @supports (height: 100dvh) {
-    #reportWrapper,
-    #reportContainer,
-    #reportContainer iframe {
-      height: calc(100dvh - var(--header-height)) !important;
-      max-height: calc(100dvh - var(--header-height)) !important;
+  @media (min-width: 768px) {
+    @supports (height: 100dvh) {
+      #reportWrapper,
+      #reportContainer,
+      #reportContainer iframe {
+        height: calc(100dvh - var(--header-height)) !important;
+        max-height: calc(100dvh - var(--header-height)) !important;
+      }
+
+      body.admin-bar #reportWrapper,
+      body.admin-bar #reportContainer,
+      body.admin-bar #reportContainer iframe {
+        height: calc(100dvh - 132px) !important;
+        max-height: calc(100dvh - 132px) !important;
+      }
     }
 
-    body.admin-bar #reportWrapper,
-    body.admin-bar #reportContainer,
-    body.admin-bar #reportContainer iframe {
-      height: calc(100dvh - 132px) !important;
-      max-height: calc(100dvh - 132px) !important;
+    @supports (height: 100svh) {
+      #reportWrapper,
+      #reportContainer,
+      #reportContainer iframe {
+        height: calc(100svh - var(--header-height)) !important;
+        max-height: calc(100svh - var(--header-height)) !important;
+      }
+      body.admin-bar #reportWrapper,
+      body.admin-bar #reportContainer,
+      body.admin-bar #reportContainer iframe {
+        height: calc(100svh - 132px) !important;
+        max-height: calc(100svh - 132px) !important;
+      }
     }
   }
-@supports (height: 100svh) {
-  #reportWrapper,
-  #reportContainer,
-  #reportContainer iframe {
-    height: calc(100svh - var(--header-height)) !important;
-    max-height: calc(100svh - var(--header-height)) !important;
-  }
-  body.admin-bar #reportWrapper,
-  body.admin-bar #reportContainer,
-  body.admin-bar #reportContainer iframe {
-    height: calc(100svh - 132px) !important;
-    max-height: calc(100svh - 132px) !important;
-  }
-}


### PR DESCRIPTION
## Summary
- prevent desktop `@supports` from overriding mobile styles in `static/embed.css`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845925e4108832f81b2566c0e1dc7aa