### PR TITLE
Handle dynamic header height before embedding

### DIFF
--- a/static/embed.css
+++ b/static/embed.css
@@ -41,11 +41,6 @@
     height: calc(100vh - var(--header-height));
   }
 
-  body.admin-bar #reportWrapper,
-  body.admin-bar #reportContainer,
-  body.admin-bar #reportContainer iframe {
-    height: calc(100vh - 132px);
-  }
 }
 
 
@@ -105,14 +100,6 @@
     display: none !important;
   }
 
-  body.admin-bar #reportWrapper,
-  body.admin-bar #reportContainer,
-  body.admin-bar #reportContainer iframe {
-    top: 132px;
-    bottom: 0;
-    height: calc(100vh - 132px) !important;
-    max-height: calc(100vh - 132px) !important;
-  }
 
   @media (min-width: 768px) {
     @supports (height: 100dvh) {
@@ -123,12 +110,6 @@
         max-height: calc(100dvh - var(--header-height)) !important;
       }
 
-      body.admin-bar #reportWrapper,
-      body.admin-bar #reportContainer,
-      body.admin-bar #reportContainer iframe {
-        height: calc(100dvh - 132px) !important;
-        max-height: calc(100dvh - 132px) !important;
-      }
     }
 
     @supports (height: 100svh) {
@@ -137,12 +118,6 @@
       #reportContainer iframe {
         height: calc(100svh - var(--header-height)) !important;
         max-height: calc(100svh - var(--header-height)) !important;
-      }
-      body.admin-bar #reportWrapper,
-      body.admin-bar #reportContainer,
-      body.admin-bar #reportContainer iframe {
-        height: calc(100svh - 132px) !important;
-        max-height: calc(100svh - 132px) !important;
       }
     }
   }

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -1,4 +1,13 @@
 window.addEventListener('DOMContentLoaded', () => {
+  // Dynamically calculate the total header height including the WP admin bar
+  const header = document.querySelector('header');
+  let offset = header ? header.offsetHeight : 0;
+  const adminBar = document.getElementById('wpadminbar');
+  if (adminBar) {
+    offset += adminBar.offsetHeight;
+  }
+  document.documentElement.style.setProperty('--header-height', offset + 'px');
+
   const container = document.getElementById('reportContainer');
   if (!container) {
     console.error("Power BI container not found.");


### PR DESCRIPTION
## Summary
- compute combined header and WordPress admin bar height in `wp-powerbi-embed.js`
- drop hardcoded admin-bar offsets from `static/embed.css`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68459a912564832f959d30fdcb795c26