### PR TITLE
Fix embed CSS duplicates

### DIFF
--- a/static/embed.css
+++ b/static/embed.css
@@ -22,8 +22,6 @@
     bottom: 0;
     left: 0;
     width: 100vw !important;
-    left: 0;
-    width: 100vw !important;
     height: calc(100vh - var(--header-height)) !important;
     max-height: calc(100vh - var(--header-height)) !important;
     max-width: 100vw !important;
@@ -41,11 +39,6 @@
     height: calc(100vh - var(--header-height));
   }
 
-  body.admin-bar #reportWrapper,
-  body.admin-bar #reportContainer,
-  body.admin-bar #reportContainer iframe {
-    height: calc(100vh - 132px);
-  }
 }
 
 
@@ -105,14 +98,6 @@
     display: none !important;
   }
 
-  body.admin-bar #reportWrapper,
-  body.admin-bar #reportContainer,
-  body.admin-bar #reportContainer iframe {
-    top: 132px;
-    bottom: 0;
-    height: calc(100vh - 132px) !important;
-    max-height: calc(100vh - 132px) !important;
-  }
 
   @media (min-width: 768px) {
     @supports (height: 100dvh) {
@@ -123,12 +108,6 @@
         max-height: calc(100dvh - var(--header-height)) !important;
       }
 
-      body.admin-bar #reportWrapper,
-      body.admin-bar #reportContainer,
-      body.admin-bar #reportContainer iframe {
-        height: calc(100dvh - 132px) !important;
-        max-height: calc(100dvh - 132px) !important;
-      }
     }
 
     @supports (height: 100svh) {
@@ -137,12 +116,6 @@
       #reportContainer iframe {
         height: calc(100svh - var(--header-height)) !important;
         max-height: calc(100svh - var(--header-height)) !important;
-      }
-      body.admin-bar #reportWrapper,
-      body.admin-bar #reportContainer,
-      body.admin-bar #reportContainer iframe {
-        height: calc(100svh - 132px) !important;
-        max-height: calc(100svh - 132px) !important;
       }
     }
   }


### PR DESCRIPTION
## Summary
- remove redundant admin-bar rules from embed.css
- drop duplicated positioning declarations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845a4516468832f83f5aebc636282ec