### PR TITLE
Adjust header height calculation

### DIFF
--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -112,9 +112,16 @@
 <script>
   document.addEventListener('DOMContentLoaded', () => {
     const header = document.querySelector('header');
+    const adminBar = document.getElementById('wpadminbar');
+    let offset = 0;
     if (header) {
-      document.documentElement.style.setProperty('--header-height', header.offsetHeight + 'px');
+      const style = getComputedStyle(header);
+      offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
     }
+    if (adminBar) {
+      offset += adminBar.offsetHeight;
+    }
+    document.documentElement.style.setProperty('--header-height', offset + 'px');
   });
 </script>
 

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -1,6 +1,18 @@
 const thisScript = document.currentScript;
 
 window.addEventListener('DOMContentLoaded', () => {
+  const header = document.querySelector('header');
+  const adminBar = document.getElementById('wpadminbar');
+  let offset = 0;
+  if (header) {
+    const style = getComputedStyle(header);
+    offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+  }
+  if (adminBar) {
+    offset += adminBar.offsetHeight;
+  }
+  document.documentElement.style.setProperty('--header-height', offset + 'px');
+
   const container = document.getElementById('reportContainer');
   if (!container) {
     console.error("Power BI container not found.");


### PR DESCRIPTION
## Summary
- compute the header offset using margin bottom
- apply offset plus admin bar height when setting `--header-height`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845a7f2775c832f81aacb3614447449