### PR TITLE
Adjust header height calculation

### DIFF
--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -47,7 +47,7 @@
   body.admin-bar #reportWrapper,
   body.admin-bar #reportContainer,
   body.admin-bar #reportContainer iframe {
-    height: calc(100vh - 132px);
+    height: calc(100vh - var(--header-height));
   }
 }
 
@@ -74,7 +74,7 @@
   body.admin-bar #reportWrapper,
   body.admin-bar #reportContainer,
   body.admin-bar #reportContainer iframe {
-    top: 132px;
+    top: var(--header-height);
     bottom: 0;
   }
 
@@ -89,8 +89,8 @@
   body.admin-bar #reportWrapper,
   body.admin-bar #reportContainer,
   body.admin-bar #reportContainer iframe {
-    height: calc(100dvh - 132px) !important;
-    max-height: calc(100dvh - 132px) !important;
+    height: calc(100dvh - var(--header-height)) !important;
+    max-height: calc(100dvh - var(--header-height)) !important;
   }
 }
 
@@ -104,18 +104,29 @@
   body.admin-bar #reportWrapper,
   body.admin-bar #reportContainer,
   body.admin-bar #reportContainer iframe {
-    height: calc(100svh - 132px) !important;
-    max-height: calc(100svh - 132px) !important;
+    height: calc(100svh - var(--header-height)) !important;
+    max-height: calc(100svh - var(--header-height)) !important;
   }
 }
 </style>
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
+  function updateHeaderOffset() {
     const header = document.querySelector('header');
+    const adminBar = document.getElementById('wpadminbar');
+    let offset = 0;
     if (header) {
-      document.documentElement.style.setProperty('--header-height', header.offsetHeight + 'px');
+      const style = getComputedStyle(header);
+      offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
     }
-  });
+    if (adminBar) {
+      offset += adminBar.offsetHeight;
+    }
+    document.documentElement.style.setProperty('--header-height', offset + 'px');
+  }
+
+  document.addEventListener('DOMContentLoaded', updateHeaderOffset);
+  window.addEventListener('load', updateHeaderOffset);
+  window.addEventListener('resize', updateHeaderOffset);
 </script>
 
 <div id="reportWrapper">

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -1,5 +1,23 @@
 const thisScript = document.currentScript;
 
+function updateHeaderOffset() {
+  const header = document.querySelector('header');
+  const adminBar = document.getElementById('wpadminbar');
+  let offset = 0;
+  if (header) {
+    const style = getComputedStyle(header);
+    offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+  }
+  if (adminBar) {
+    offset += adminBar.offsetHeight;
+  }
+  document.documentElement.style.setProperty('--header-height', offset + 'px');
+}
+
+window.addEventListener('DOMContentLoaded', updateHeaderOffset);
+window.addEventListener('load', updateHeaderOffset);
+window.addEventListener('resize', updateHeaderOffset);
+
 window.addEventListener('DOMContentLoaded', () => {
   const container = document.getElementById('reportContainer');
   if (!container) {


### PR DESCRIPTION
## Summary
- compute the header offset using margin bottom
- apply offset plus admin bar height when setting `--header-height`
- recompute header offset on load and resize events
- use the `--header-height` variable for admin bar rules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845a7f2775c832f81aacb3614447449