### PR TITLE
Fix header offset calculation

### DIFF
--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -116,7 +116,10 @@
     let offset = 0;
     if (header) {
       const style = getComputedStyle(header);
-      offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+      offset =
+      header.offsetHeight +
+      parseFloat(style.marginBottom || '0') +
+      parseFloat(style.borderBottomWidth || '0');
     }
     if (adminBar) {
       offset += adminBar.offsetHeight;

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -6,7 +6,10 @@ function updateHeaderOffset() {
   let offset = 0;
   if (header) {
     const style = getComputedStyle(header);
-    offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+    offset =
+    header.offsetHeight +
+    parseFloat(style.marginBottom || '0') +
+    parseFloat(style.borderBottomWidth || '0');
   }
   if (adminBar) {
     offset += adminBar.offsetHeight;
@@ -24,7 +27,10 @@ window.addEventListener('DOMContentLoaded', () => {
   let offset = 0;
   if (header) {
     const style = getComputedStyle(header);
-    offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+    offset =
+    header.offsetHeight +
+    parseFloat(style.marginBottom || '0') +
+    parseFloat(style.borderBottomWidth || '0');
   }
   if (adminBar) {
     offset += adminBar.offsetHeight;


### PR DESCRIPTION
## Summary
- adjust the header offset calculation to include bottom border width
- keep inline example in `embed-html-call-from-render` consistent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845b2c77f34832f84eeaa73241ed330