### PR TITLE
Fix mobile header offset

### DIFF
--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -116,7 +116,10 @@
     let offset = 0;
     if (header) {
       const style = getComputedStyle(header);
-      offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+      offset =
+        header.offsetHeight +
+        parseFloat(style.marginBottom || '0') +
+        parseFloat(style.borderBottomWidth || '0');
     }
     if (adminBar) {
       offset += adminBar.offsetHeight;

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -6,7 +6,10 @@ function updateHeaderOffset() {
   let offset = 0;
   if (header) {
     const style = getComputedStyle(header);
-    offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+    offset =
+      header.offsetHeight +
+      parseFloat(style.marginBottom || '0') +
+      parseFloat(style.borderBottomWidth || '0');
   }
   if (adminBar) {
     offset += adminBar.offsetHeight;
@@ -24,7 +27,10 @@ window.addEventListener('DOMContentLoaded', () => {
   let offset = 0;
   if (header) {
     const style = getComputedStyle(header);
-    offset = header.offsetHeight + parseFloat(style.marginBottom || '0');
+    offset =
+      header.offsetHeight +
+      parseFloat(style.marginBottom || '0') +
+      parseFloat(style.borderBottomWidth || '0');
   }
   if (adminBar) {
     offset += adminBar.offsetHeight;


### PR DESCRIPTION
## Summary
- include border-bottom in header offset logic for embed JS
- adjust inline render snippet the same way

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae52fe1c832fa97137c1cf89ea0d