### PR TITLE
Adjust embed height for mobile

### DIFF
--- a/static/embed.css
+++ b/static/embed.css
@@ -19,11 +19,11 @@
   #reportContainer iframe {
     position: fixed;
     top: var(--header-height);
-    bottom: 0;
+    bottom: env(safe-area-inset-bottom, 0);
     left: 0;
     width: 100vw !important;
-    height: calc(100vh - var(--header-height)) !important;
-    max-height: calc(100vh - var(--header-height)) !important;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     max-width: 100vw !important;
     margin: 0;
     padding: 0;
@@ -58,31 +58,31 @@
   #reportWrapper {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height));
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0));
     overflow: auto;
   }
 
   #reportContainer {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height)) !important;
-    max-height: calc(100vh - var(--header-height)) !important;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     overflow: auto;
   }
 
   @supports (height: 100dvh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100dvh - var(--header-height)) !important;
-      max-height: calc(100dvh - var(--header-height)) !important;
+      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     }
   }
 
   @supports (height: 100svh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100svh - var(--header-height)) !important;
-      max-height: calc(100svh - var(--header-height)) !important;
+      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     }
   }
 
@@ -104,8 +104,8 @@
       #reportWrapper,
       #reportContainer,
       #reportContainer iframe {
-        height: calc(100dvh - var(--header-height)) !important;
-        max-height: calc(100dvh - var(--header-height)) !important;
+        height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+        max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
       }
 
     }
@@ -114,8 +114,8 @@
       #reportWrapper,
       #reportContainer,
       #reportContainer iframe {
-        height: calc(100svh - var(--header-height)) !important;
-        max-height: calc(100svh - var(--header-height)) !important;
+        height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+        max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
       }
     }
   }


### PR DESCRIPTION
## Summary
- use `env(safe-area-inset-bottom)` in the embed stylesheet so Power BI embeds fit the mobile viewport

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845bc9a38a8832f983c6ea3eec5df26