### PR TITLE
Fix duplicate offset calculation in embed script

### DIFF
--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -10,9 +10,6 @@ function updateHeaderOffset() {
       header.offsetHeight +
       parseFloat(style.marginBottom || '0') +
       parseFloat(style.borderBottomWidth || '0');
-    header.offsetHeight +
-    parseFloat(style.marginBottom || '0') +
-    parseFloat(style.borderBottomWidth || '0');
   }
   if (adminBar) {
     offset += adminBar.offsetHeight;
@@ -34,9 +31,6 @@ window.addEventListener('DOMContentLoaded', () => {
       header.offsetHeight +
       parseFloat(style.marginBottom || '0') +
       parseFloat(style.borderBottomWidth || '0');
-    header.offsetHeight +
-    parseFloat(style.marginBottom || '0') +
-    parseFloat(style.borderBottomWidth || '0');
   }
   if (adminBar) {
     offset += adminBar.offsetHeight;


### PR DESCRIPTION
## Summary
- clean up wp-powerbi-embed.js to calculate offset only once

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6845c3f525c4832fbf795a1ce6cd0f91