### PR TITLE
Add embed2.css and restore original embed.css

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -1,0 +1,83 @@
+  :root {
+    --header-height: 95px;
+  }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+  }
+
+  header, .site-header {
+    z-index: 1100;
+  }
+
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    position: fixed;
+    top: var(--header-height);
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 0;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    margin: 0;
+    padding: 0;
+    border: none;
+    overflow: auto;
+    z-index: 1000;
+  }
+
+  @media (max-width: 767px) {
+    :root {
+      --header-height: 80px;
+    }
+
+    html,
+    body {
+      overflow: auto;
+    }
+
+  /* Mobile: allow scrolling for tall reports */
+  #reportWrapper {
+    position: fixed;
+    top: var(--header-height);
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 0;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    overflow: auto;
+  }
+
+  #reportContainer {
+    position: fixed;
+    top: var(--header-height);
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 0;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    overflow: auto;
+  }
+
+  #reportContainer iframe {
+    position: fixed;
+    top: var(--header-height);
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 0;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    border: none;
+    margin: 0;
+    padding: 0;
+    overflow: auto;
+    z-index: 1000;
+  }
+  }
+
+  footer, .site-footer {
+    display: none !important;
+  }
+
+


### PR DESCRIPTION
## Summary
- restore original layout in `embed.css`
- add `embed2.css` with the updated top/bottom layout for testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845d18be32c832f8cb04e84c923579b