### PR TITLE
Add embed2 variant with slightly reduced height

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -1,0 +1,121 @@
+  :root {
+    --header-height: 95px;
+  }
+
+  html, body {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    overflow: auto;
+  }
+
+  header, .site-header {
+    z-index: 1100;
+  }
+
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    position: fixed;
+    top: var(--header-height);
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 0;
+    width: 100vw !important;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+    max-width: 100vw !important;
+    margin: 0;
+    padding: 0;
+    border: none;
+    overflow: auto;
+    z-index: 1000;
+  }
+
+@supports not (height: 100dvh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100vh - var(--header-height) - 3px);
+  }
+
+}
+
+
+
+
+  @media (max-width: 767px) {
+    :root {
+      --header-height: 80px;
+    }
+
+    html,
+    body {
+      overflow: auto;
+    }
+
+  /* Mobile: allow scrolling for tall reports */
+  #reportWrapper {
+    position: static;
+    width: 100%;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px);
+    overflow: auto;
+  }
+
+  #reportContainer {
+    position: static;
+    width: 100%;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+    overflow: auto;
+  }
+
+  @supports (height: 100dvh) {
+    #reportWrapper,
+    #reportContainer {
+      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+    }
+  }
+
+  @supports (height: 100svh) {
+    #reportWrapper,
+    #reportContainer {
+      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+    }
+  }
+
+  #reportContainer iframe {
+    position: static;
+    height: 100% !important;
+    width: 100% !important;
+    display: block;
+  }
+  }
+
+  footer, .site-footer {
+    display: none !important;
+  }
+
+
+  @media (min-width: 768px) {
+    @supports (height: 100dvh) {
+      #reportWrapper,
+      #reportContainer,
+      #reportContainer iframe {
+        height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+        max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+      }
+
+    }
+
+    @supports (height: 100svh) {
+      #reportWrapper,
+      #reportContainer,
+      #reportContainer iframe {
+        height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+        max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+      }
+    }
+  }


### PR DESCRIPTION
## Summary
- create a new `embed2.css` based on `embed.css`
- reduce all calculated heights by 3px for troubleshooting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845d18be32c832f8cb04e84c923579b