### PR TITLE
Add alternate embed2 layout for mobile tabs

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -1,0 +1,53 @@
+/* embed2 variant: reduce header offset by 3px using top/bottom sizing */
+:root {
+  --header-height: 95px;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+}
+
+header, .site-header {
+  z-index: 1100;
+}
+
+#reportWrapper,
+#reportContainer,
+#reportContainer iframe {
+  position: fixed;
+  top: calc(var(--header-height) - 3px);
+  bottom: env(safe-area-inset-bottom, 0);
+  left: 0;
+  width: 100vw !important;
+  max-width: 100vw !important;
+  margin: 0;
+  padding: 0;
+  border: none;
+  overflow: auto;
+  z-index: 1000;
+}
+
+@media (max-width: 767px) {
+  :root {
+    --header-height: 80px;
+  }
+
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    position: fixed;
+    top: calc(var(--header-height) - 3px);
+    bottom: env(safe-area-inset-bottom, 0);
+    left: 0;
+    width: 100vw !important;
+    max-width: 100vw !important;
+    overflow: auto;
+  }
+}
+
+footer, .site-footer {
+  display: none !important;
+}


### PR DESCRIPTION
## Summary
- revamp `embed2.css` so it uses `top`/`bottom` offsets instead of height calculations
- subtract 3px from the header offset for troubleshooting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6845d18be32c832f8cb04e84c923579b