### PR TITLE
Adjust embed2 mobile bottom offset

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -1,91 +1,89 @@
-/* embed2 variant: header height reduced by 3px for testing */
-  :root {
-    --header-height: 95px;
-  }
+/* embed2 variant: standard header offset with no extra reduction */
 
-  html, body {
-    margin: 0;
-    padding: 0;
-    height: 100%;
-    width: 100%;
-    overflow: auto;
-  }
+:root {
+  --header-height: 95px;
+}
 
-  header, .site-header {
-    z-index: 1100;
-  }
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  overflow: auto;
+}
 
-  #reportWrapper,
-  #reportContainer,
-  #reportContainer iframe {
-    position: fixed;
-    top: var(--header-height);
-    bottom: env(safe-area-inset-bottom, 0);
-    left: 0;
-    width: 100vw !important;
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-    max-width: 100vw !important;
-    margin: 0;
-    padding: 0;
-    border: none;
-    overflow: auto;
-    z-index: 1000;
-  }
+header,
+.site-header {
+  z-index: 1100;
+}
+
+#reportWrapper,
+#reportContainer,
+#reportContainer iframe {
+  position: fixed;
+  top: var(--header-height);
+  bottom: 0;
+  left: 0;
+  width: 100vw !important;
+  height: calc(100vh - var(--header-height)) !important;
+  max-height: calc(100vh - var(--header-height)) !important;
+  max-width: 100vw !important;
+  margin: 0;
+  padding: 0;
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  border: none;
+  overflow: auto;
+  z-index: 1000;
+}
 
 @supports not (height: 100dvh) {
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100vh - var(--header-height) - 3px);
+    height: calc(100vh - var(--header-height));
+  }
+}
+
+@media (max-width: 767px) {
+  :root {
+    --header-height: 80px;
   }
 
-}
-  @media (max-width: 767px) {
-    :root {
-      --header-height: 80px;
-    }
-
-    html,
-    body {
-      overflow: auto;
-    }
+  html,
+  body {
+    overflow: auto;
+  }
 
   /* Mobile: allow scrolling for tall reports */
   #reportWrapper {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px);
-    position: fixed;
-    top: var(--header-height);
-    bottom: env(safe-area-inset-bottom, 0);
-    left: 0;
-    width: 100vw !important;
-    max-width: 100vw !important;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0));
     overflow: auto;
   }
 
   #reportContainer {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     overflow: auto;
   }
 
   @supports (height: 100dvh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
   }
 
   @supports (height: 100svh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
+      height: calc(100svh - var(--header-height)) !important;
+      max-height: calc(100svh - var(--header-height)) !important;
     }
   }
 
@@ -94,51 +92,30 @@
     height: 100% !important;
     width: 100% !important;
     display: block;
-    position: fixed;
-    top: var(--header-height);
-    bottom: env(safe-area-inset-bottom, 0);
-    left: 0;
-    width: 100vw !important;
-    max-width: 100vw !important;
-    overflow: auto;
   }
-  #reportContainer iframe {
-    position: fixed;
-    top: var(--header-height);
-    bottom: env(safe-area-inset-bottom, 0);
-    left: 0;
-    width: 100vw !important;
-    max-width: 100vw !important;
-    border: none;
-    margin: 0;
-    padding: 0;
-    overflow: auto;
-    z-index: 1000;
-  }
-  }
+}
 
-  footer, .site-footer {
-    display: none !important;
-  }
+footer,
+.site-footer {
+  display: none !important;
+}
 
-
-  @media (min-width: 768px) {
-    @supports (height: 100dvh) {
-      #reportWrapper,
-      #reportContainer,
-      #reportContainer iframe {
-        height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-        max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-      }
-
-    }
-
-    @supports (height: 100svh) {
-      #reportWrapper,
-      #reportContainer,
-      #reportContainer iframe {
-        height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-        max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0) - 3px) !important;
-      }
+@media (min-width: 768px) {
+  @supports (height: 100dvh) {
+    #reportWrapper,
+    #reportContainer,
+    #reportContainer iframe {
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
   }
+
+  @supports (height: 100svh) {
+    #reportWrapper,
+    #reportContainer,
+    #reportContainer iframe {
+      height: calc(100svh - var(--header-height)) !important;
+      max-height: calc(100svh - var(--header-height)) !important;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- tweak embed2.css so fixed containers reach the bottom
- drop safe-area offset from height calculations
- pad the bottom using safe-area inset instead

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6846ca7528e0832f8093c164a478021f