### PR TITLE
Fix embed CSS safe area

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -24,11 +24,12 @@ header,
 #reportContainer iframe {
   position: fixed;
   top: var(--header-height);
-  bottom: env(safe-area-inset-bottom, 0);
+  bottom: 0;
+  padding-bottom: env(safe-area-inset-bottom, 0);
   left: 0;
   width: 100vw !important;
-  height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-  max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+  height: calc(100vh - var(--header-height)) !important;
+  max-height: calc(100vh - var(--header-height)) !important;
   max-width: 100vw !important;
   margin: 0;
   padding: 0;
@@ -59,31 +60,31 @@ header,
   #reportWrapper {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0));
+    height: calc(100vh - var(--header-height));
     overflow: auto;
   }
 
   #reportContainer {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+    height: calc(100vh - var(--header-height)) !important;
+    max-height: calc(100vh - var(--header-height)) !important;
     overflow: auto;
   }
 
   @supports (height: 100dvh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
   }
 
   @supports (height: 100svh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100svh - var(--header-height)) !important;
+      max-height: calc(100svh - var(--header-height)) !important;
     }
   }
 
@@ -105,8 +106,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
 
     }
   }
@@ -115,8 +116,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100svh - var(--header-height)) !important;
+      max-height: calc(100svh - var(--header-height)) !important;
 
     }
   }


### PR DESCRIPTION
## Summary
- tweak embed2.css to remove safe area height offset and add padding

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68473a2ead9c832f8ec1380d4eb74bb4