### PR TITLE
Remove stray closing bracket

### DIFF
--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -129,7 +129,6 @@
   document.addEventListener('DOMContentLoaded', updateHeaderOffset);
   window.addEventListener('load', updateHeaderOffset);
   window.addEventListener('resize', updateHeaderOffset);
-  });
 </script>
 
 <div id="reportWrapper">


### PR DESCRIPTION
## Summary
- fix extra closing bracket in `embed-html-call-from-render`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68473f7fae28832f9aa74f04c35ce89b