### PR TITLE
Fix safe area bottom in embed CSS

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -22,12 +22,12 @@ header,
 #reportContainer iframe {
   position: fixed;
   top: var(--header-height);
-  bottom: 0;
+  bottom: env(safe-area-inset-bottom, 0);
   padding-bottom: env(safe-area-inset-bottom, 0);
   left: 0;
   width: 100vw !important;
-  height: calc(100vh - var(--header-height)) !important;
-  max-height: calc(100vh - var(--header-height)) !important;
+  height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+  max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
   max-width: 100vw !important;
   margin: 0;
   padding: 0;
@@ -40,7 +40,7 @@ header,
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100vh - var(--header-height));
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0));
   }
 }
 
@@ -65,24 +65,24 @@ header,
   #reportContainer {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height)) !important;
-    max-height: calc(100vh - var(--header-height)) !important;
+    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     overflow: auto;
   }
 
   @supports (height: 100dvh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100dvh - var(--header-height)) !important;
-      max-height: calc(100dvh - var(--header-height)) !important;
+      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     }
   }
 
   @supports (height: 100svh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100svh - var(--header-height)) !important;
-      max-height: calc(100svh - var(--header-height)) !important;
+      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     }
   }
 
@@ -104,8 +104,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - var(--header-height)) !important;
-      max-height: calc(100dvh - var(--header-height)) !important;
+      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     }
   }
 
@@ -113,8 +113,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100svh - var(--header-height)) !important;
-      max-height: calc(100svh - var(--header-height)) !important;
+      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     }
   }
 }


### PR DESCRIPTION
## Summary
- respect safe area bottom inset for reports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_684746a305a0832f8792b66cf5e66dca