### PR TITLE
Add loading overlay for PowerBI reports

### DIFF
--- a/static/embedScript.js
+++ b/static/embedScript.js
@@ -1,4 +1,24 @@
+
 (function () {
+  const container = document.getElementById("reportContainer");
+  const loading = document.createElement("div");
+  loading.id = "powerbi-loading";
+  loading.textContent = "Loading Power BI...";
+  loading.style.position = "absolute";
+  loading.style.top = "0";
+  loading.style.left = "0";
+  loading.style.right = "0";
+  loading.style.bottom = "0";
+  loading.style.display = "flex";
+  loading.style.alignItems = "center";
+  loading.style.justifyContent = "center";
+  loading.style.backgroundColor = "rgba(255, 255, 255, 0.8)";
+  loading.style.zIndex = "2000";
+  if (getComputedStyle(container).position === "static") {
+    container.style.position = "relative";
+  }
+  container.appendChild(loading);
+
   const sdkScript = document.createElement("script");
   sdkScript.src = "https://cdn.jsdelivr.net/npm/powerbi-client@2.21.0/dist/powerbi.min.js";
 
@@ -18,6 +38,7 @@
         if (!data.token || !data.embedUrl) {
           container.innerText = "Invalid token response.";
           console.error("Token response error:", data);
+          loading.remove();
           return;
         }
 
@@ -42,21 +63,27 @@
 
         container.innerHTML = "";
         const report = powerbi.embed(container, config);
-        report.on("loaded", () => console.log("✅ Power BI report loaded"));
+        report.on("loaded", () => {
+          loading.remove();
+          console.log("✅ Power BI report loaded");
+        });
         report.on("error", err => {
           console.error("❌ Power BI render error:", err.detail);
           container.innerText = "Power BI failed to render.";
+          loading.remove();
         });
       })
       .catch(err => {
         console.error("Fetch error:", err);
         container.innerText = "Failed to fetch embed token.";
+        loading.remove();
       });
   };
 
   sdkScript.onerror = () => {
     console.error("❌ Failed to load Power BI SDK");
     document.getElementById("reportContainer").innerText = "Failed to load SDK.";
+    loading.remove();
   };
 
   document.body.appendChild(sdkScript);

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -71,6 +71,25 @@ window.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
+  // Show loading overlay
+  const loading = document.createElement('div');
+  loading.id = 'powerbi-loading';
+  loading.textContent = 'Loading Power BI...';
+  loading.style.position = 'absolute';
+  loading.style.top = '0';
+  loading.style.left = '0';
+  loading.style.right = '0';
+  loading.style.bottom = '0';
+  loading.style.display = 'flex';
+  loading.style.alignItems = 'center';
+  loading.style.justifyContent = 'center';
+  loading.style.backgroundColor = 'rgba(255, 255, 255, 0.8)';
+  loading.style.zIndex = '2000';
+  if (getComputedStyle(container).position === 'static') {
+    container.style.position = 'relative';
+  }
+  container.appendChild(loading);
+
   const sdkScript = document.createElement('script');
   sdkScript.src = 'https://cdn.jsdelivr.net/npm/powerbi-client@2.21.0/dist/powerbi.min.js';
 
@@ -86,6 +105,7 @@ window.addEventListener('DOMContentLoaded', () => {
         if (!data.token || !data.embedUrl) {
           container.innerText = "Failed to load embed config.";
           console.error("Embed token response invalid:", data);
+          loading.remove();
           return;
         }
 
@@ -111,17 +131,21 @@ window.addEventListener('DOMContentLoaded', () => {
         };
 
         container.innerHTML = '';
-        window.powerbi.embed(container, config);
+        const report = window.powerbi.embed(container, config);
+        report.on('loaded', () => loading.remove());
+        report.on('error', () => loading.remove());
       })
       .catch(err => {
         container.innerText = "Failed to load Power BI report.";
         console.error("Power BI embed fetch error:", err);
+        loading.remove();
       });
   };
 
   sdkScript.onerror = () => {
     container.innerText = "Failed to load Power BI SDK.";
     console.error("Power BI SDK load error.");
+    loading.remove();
   };
 
   document.body.appendChild(sdkScript);


### PR DESCRIPTION
## Summary
- show a Loading overlay before requesting the embed token
- hide the overlay once the report loads or when an error occurs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_684746af6990832fabb6fe0ca923e9d5