### PR TITLE
Update embed CSS for safe area

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -22,8 +22,8 @@ header,
 #reportContainer iframe {
   position: fixed;
   top: var(--header-height);
-  bottom: env(safe-area-inset-bottom, 0);
-  padding-bottom: env(safe-area-inset-bottom, 0);
+  bottom: 0;
+  /* padding-bottom: env(safe-area-inset-bottom, 0); */
   left: 0;
   width: 100vw !important;
   height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
@@ -66,7 +66,7 @@ header,
     position: static;
     width: 100%;
     height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+    max-height: calc(100vh - var(--header-height)) !important;
     overflow: auto;
   }
 
@@ -74,7 +74,7 @@ header,
     #reportWrapper,
     #reportContainer {
       height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
   }
 
@@ -82,7 +82,7 @@ header,
     #reportWrapper,
     #reportContainer {
       height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100svh - var(--header-height)) !important;
     }
   }
 
@@ -105,7 +105,7 @@ footer,
     #reportContainer,
     #reportContainer iframe {
       height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
   }
 
@@ -114,7 +114,7 @@ footer,
     #reportContainer,
     #reportContainer iframe {
       height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100svh - var(--header-height)) !important;
     }
   }
 }


### PR DESCRIPTION
## Summary
- tweak embed2 css to handle safe area insets

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_684754161dcc832f8136afd1cb758b99