### PR TITLE
Fix safe area gap in embed2.css

### DIFF
--- a/static/embed.css
+++ b/static/embed.css
@@ -110,12 +110,25 @@
 
     }
 
-    @supports (height: 100svh) {
-      #reportWrapper,
-      #reportContainer,
-      #reportContainer iframe {
-        height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-        max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      }
+  @supports (height: 100svh) {
+    #reportWrapper,
+    #reportContainer,
+    #reportContainer iframe {
+      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
     }
   }
+  }
+
+#powerbi-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.8);
+  z-index: 2000;
+}

--- a/static/embed2.css
+++ b/static/embed2.css
@@ -22,8 +22,7 @@ header,
 #reportContainer iframe {
   position: fixed;
   top: var(--header-height);
-  bottom: 0;
-  /* padding-bottom: env(safe-area-inset-bottom, 0); */
+  bottom: env(safe-area-inset-bottom, 0);
   left: 0;
   width: 100vw !important;
   height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
@@ -117,4 +116,17 @@ footer,
       max-height: calc(100svh - var(--header-height)) !important;
     }
   }
+}
+
+#powerbi-loading {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.8);
+  z-index: 2000;
 }

--- a/static/embedScript.js
+++ b/static/embedScript.js
@@ -41,9 +41,17 @@
         };
 
         container.innerHTML = "";
+        const overlay = document.createElement("div");
+        overlay.id = "powerbi-loading";
+        overlay.textContent = "Loading Power BI...";
+        container.appendChild(overlay);
         const report = powerbi.embed(container, config);
-        report.on("loaded", () => console.log("✅ Power BI report loaded"));
+        report.on("loaded", () => {
+          overlay.remove();
+          console.log("✅ Power BI report loaded");
+        });
         report.on("error", err => {
+          overlay.remove();
           console.error("❌ Power BI render error:", err.detail);
           container.innerText = "Power BI failed to render.";
         });

--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -111,7 +111,21 @@ window.addEventListener('DOMContentLoaded', () => {
         };
 
         container.innerHTML = '';
-        window.powerbi.embed(container, config);
+
+        const overlay = document.createElement('div');
+        overlay.id = 'powerbi-loading';
+        overlay.textContent = 'Loading Power BI...';
+        container.appendChild(overlay);
+
+        const report = window.powerbi.embed(container, config);
+        report.on('loaded', () => {
+          overlay.remove();
+        });
+        report.on('error', err => {
+          overlay.remove();
+          container.innerText = 'Power BI failed to render.';
+          console.error('Power BI render error:', err.detail);
+        });
       })
       .catch(err => {
         container.innerText = "Failed to load Power BI report.";


### PR DESCRIPTION
## Summary
- adjust bottom offset in embed2.css for safe-area bottom
- add overlay style so loading message is centered

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - app)*

------
https://chatgpt.com/codex/tasks/task_e_68475c439f28832fb6de400afc8aaf19