### PR TITLE
Add tests for failure scenarios

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -50,3 +50,63 @@ def test_get_embed_token_missing_params(client):
     assert response.status_code == 400
     data = response.get_json()
     assert "error" in data
+
+
+@pytest.fixture
+def client_aad_failure(monkeypatch):
+    """Create a test client where Azure AD token acquisition fails."""
+    monkeypatch.setattr(app, "CLIENT_SECRET", "dummy-secret")
+
+    class FakeMSALApp:
+        def acquire_token_for_client(self, scopes=None):
+            return {"error": "invalid_client"}
+
+    monkeypatch.setattr(app.msal, "ConfidentialClientApplication", lambda *a, **k: FakeMSALApp())
+    monkeypatch.setattr(app.requests, "post", lambda *a, **k: None)
+
+    with app.app.test_client() as c:
+        yield c
+
+
+def test_aad_token_failure(client_aad_failure):
+    response = client_aad_failure.get(
+        "/getEmbedToken",
+        query_string={"reportId": "r1", "groupId": "g1", "datasetId": "d1"},
+    )
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["error"] == "Failed to acquire Azure AD token"
+    assert data["details"] == {"error": "invalid_client"}
+
+
+@pytest.fixture
+def client_powerbi_failure(monkeypatch):
+    """Create a test client where the Power BI API returns an error."""
+    monkeypatch.setattr(app, "CLIENT_SECRET", "dummy-secret")
+
+    class FakeMSALApp:
+        def acquire_token_for_client(self, scopes=None):
+            return {"access_token": "aad-token"}
+
+    class FakeResponse:
+        status_code = 400
+        text = "bad request"
+        def json(self):
+            return {}
+
+    monkeypatch.setattr(app.msal, "ConfidentialClientApplication", lambda *a, **k: FakeMSALApp())
+    monkeypatch.setattr(app.requests, "post", lambda *a, **k: FakeResponse())
+
+    with app.app.test_client() as c:
+        yield c
+
+
+def test_powerbi_api_failure(client_powerbi_failure):
+    response = client_powerbi_failure.get(
+        "/getEmbedToken",
+        query_string={"reportId": "r1", "groupId": "g1", "datasetId": "d1"},
+    )
+    assert response.status_code == 500
+    data = response.get_json()
+    assert data["error"] == "Failed to generate embed token"
+    assert data["details"] == "bad request"


### PR DESCRIPTION
## Summary
- expand test coverage to include Azure AD and Power BI API error cases

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask==2.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68475f4139ac832f958091f2d2cac97a