### PR TITLE
Fix redundant header offset code

### DIFF
--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -21,19 +21,7 @@ window.addEventListener('load', updateHeaderOffset);
 window.addEventListener('resize', updateHeaderOffset);
 
 window.addEventListener('DOMContentLoaded', () => {
-  const header = document.querySelector('header');
-  const adminBar = document.getElementById('wpadminbar');
-  let offset = 0;
-  if (header) {
-    const style = getComputedStyle(header);
-    offset =
-      header.offsetHeight +
-      parseFloat(style.marginBottom || '0');
-  }
-  if (adminBar) {
-    offset += adminBar.offsetHeight;
-  }
-  document.documentElement.style.setProperty('--header-height', offset + 'px');
+  updateHeaderOffset();
 
   const container = document.getElementById('reportContainer');
   if (!container) {


### PR DESCRIPTION
## Summary
- deduplicate header offset logic by calling `updateHeaderOffset()` inside the DOMContentLoaded handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68475f39dfb0832f9d3122c8193813a2