### PR TITLE
Fix viewport unit logic

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -25,8 +25,8 @@ header,
   bottom: env(safe-area-inset-bottom, 0);
   left: 0;
   width: 100vw !important;
-  height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-  max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+  height: calc(100vh - var(--header-height)) !important;
+  max-height: calc(100vh - var(--header-height)) !important;
   max-width: 100vw !important;
   margin: 0;
   padding: 0;
@@ -39,7 +39,16 @@ header,
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0));
+    height: calc(100vh - var(--header-height));
+  }
+}
+
+@supports (height: 100dvh) {
+  #reportWrapper,
+  #reportContainer,
+  #reportContainer iframe {
+    height: calc(100dvh - var(--header-height)) !important;
+    max-height: calc(100dvh - var(--header-height)) !important;
   }
 }
 
@@ -103,8 +112,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100dvh - var(--header-height)) !important;
+      max-height: calc(100dvh - var(--header-height)) !important;
     }
   }
 
@@ -112,8 +121,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100svh - var(--header-height)) !important;
+      max-height: calc(100svh - var(--header-height)) !important;
     }
   }
 }


### PR DESCRIPTION
## Summary
- adjust report container height calculations to use dynamic viewport units

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68487cfb8cbc832f8b86a2fb87a138fa