### PR TITLE
Update header height docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ Include `wp-powerbi-embed.js` on your WordPress page and provide the report info
 <script src="/path/to/wp-powerbi-embed.js"></script>
 ```
 
-The stylesheet defines a `--header-height` CSS custom property with a default
-value of `95px`. Override this variable in your own CSS if your theme's header
-height differs:
+The `embed2.css` stylesheet defines a `--header-height` CSS custom property with
+a default value of `80px`. You can override this variable in your own CSS if
+your theme's header height differs:
 
 ```css
 :root {

--- a/embed-html-call-from-render
+++ b/embed-html-call-from-render
@@ -1,7 +1,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
   :root {
-    --header-height: 95px;
+    --header-height: 80px;
   }
 
   html, body {


### PR DESCRIPTION
## Summary
- document `--header-height` as `80px` for embed2.css
- remove outdated `95px` value in HTML example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6848a2a633f8832f99076860803e96d4