### PR TITLE
Fix double DOMContentLoaded handler

### DIFF
--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -16,7 +16,6 @@ function updateHeaderOffset() {
   document.documentElement.style.setProperty('--header-height', offset + 'px');
 }
 
-window.addEventListener('DOMContentLoaded', updateHeaderOffset);
 window.addEventListener('load', updateHeaderOffset);
 window.addEventListener('resize', updateHeaderOffset);
 


### PR DESCRIPTION
## Summary
- clean up DOMContentLoaded listener

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6848a2acec58832fabc0cb819165b6d3