### PR TITLE
Fix mobile height calculations

### DIFF
--- a/static/embed2.css
+++ b/static/embed2.css
@@ -21,12 +21,12 @@ header,
 #reportContainer,
 #reportContainer iframe {
   position: fixed;
-  top: var(--header-height);
+  top: calc(var(--header-height) + 3px);
   bottom: env(safe-area-inset-bottom, 0);
   left: 0;
   width: 100vw !important;
-  height: calc(100vh - var(--header-height)) !important;
-  max-height: calc(100vh - var(--header-height)) !important;
+  height: calc(100vh - var(--header-height) - 3px) !important;
+  max-height: calc(100vh - var(--header-height) - 3px) !important;
   max-width: 100vw !important;
   margin: 0;
   padding: 0;
@@ -39,7 +39,7 @@ header,
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100vh - var(--header-height));
+    height: calc(100vh - var(--header-height) - 3px);
   }
 }
 
@@ -47,8 +47,8 @@ header,
   #reportWrapper,
   #reportContainer,
   #reportContainer iframe {
-    height: calc(100dvh - var(--header-height)) !important;
-    max-height: calc(100dvh - var(--header-height)) !important;
+    height: calc(100dvh - var(--header-height) - 3px) !important;
+    max-height: calc(100dvh - var(--header-height) - 3px) !important;
   }
 }
 
@@ -66,31 +66,31 @@ header,
   #reportWrapper {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0));
+    height: calc(100vh - var(--header-height) + 3px);
     overflow: auto;
   }
 
   #reportContainer {
     position: static;
     width: 100%;
-    height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-    max-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+    height: calc(100vh - var(--header-height) + 3px) !important;
+    max-height: calc(100vh - var(--header-height) + 3px) !important;
     overflow: auto;
   }
 
   @supports (height: 100dvh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100dvh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100dvh - var(--header-height) + 3px) !important;
+      max-height: calc(100dvh - var(--header-height) + 3px) !important;
     }
   }
 
   @supports (height: 100svh) {
     #reportWrapper,
     #reportContainer {
-      height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
-      max-height: calc(100svh - var(--header-height) - env(safe-area-inset-bottom, 0)) !important;
+      height: calc(100svh - var(--header-height) + 3px) !important;
+      max-height: calc(100svh - var(--header-height) + 3px) !important;
     }
   }
 
@@ -112,8 +112,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100dvh - var(--header-height)) !important;
-      max-height: calc(100dvh - var(--header-height)) !important;
+      height: calc(100dvh - var(--header-height) - 3px) !important;
+      max-height: calc(100dvh - var(--header-height) - 3px) !important;
     }
   }
 
@@ -121,8 +121,8 @@ footer,
     #reportWrapper,
     #reportContainer,
     #reportContainer iframe {
-      height: calc(100svh - var(--header-height)) !important;
-      max-height: calc(100svh - var(--header-height)) !important;
+      height: calc(100svh - var(--header-height) - 3px) !important;
+      max-height: calc(100svh - var(--header-height) - 3px) !important;
     }
   }
 }


### PR DESCRIPTION
## Summary
- tweak mobile layout to remove safe area inset from dynamic height formulas
- adjust layout margins

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6848a2b07e08832f901b4a60af571ea6