### PR TITLE
Force embedded reports to fit container width

### DIFF
--- a/wp-powerbi-embed.js
+++ b/wp-powerbi-embed.js
@@ -86,6 +86,7 @@ window.addEventListener('DOMContentLoaded', () => {
           tokenType: models.TokenType.Embed,
           settings: {
             layoutType: models.LayoutType.Custom,
+            pageView: models.PageView.fitToWidth,
             navContentPaneEnabled: true,
             panes: {
               navigationPane: { visible: true },


### PR DESCRIPTION
## Summary
- default embedded Power BI reports to use `PageView.fitToWidth`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*
- `pip install -r requirements.txt` *(fails: could not find Flask due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6848b39bb95c832fba316897bb176033