### PR TITLE
Add RLS docs and role name env

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ Use `venv\Scripts\activate.bat` for the Command Prompt.
 
 ## Configuration
 
-Update `TENANT_ID`, `CLIENT_ID` and the allowed CORS domain at the top of `app.py` if needed. The application expects a `CLIENT_SECRET` environment variable. Set it in your shell before starting the app:
+Update `TENANT_ID`, `CLIENT_ID` and the allowed CORS domain at the top of `app.py` if needed. The application expects a `CLIENT_SECRET` environment variable. Set it in your shell before starting the app.  
+`appv2.py` also honors an optional `RLS_ROLE_NAME` variable for row-level security (defaults to `UserEmailRole`):
 
 ```bash
 export CLIENT_SECRET="<your AAD app client secret>"
+export RLS_ROLE_NAME="<dataset role name>"  # optional
 ```
 
 ## Running the server
@@ -44,7 +46,12 @@ After installing the dependencies and setting `CLIENT_SECRET`, start the Flask a
 python app.py
 ```
 
+
 The server will listen on port `5000` by default. The embed token endpoint will be available at `http://localhost:5000/getEmbedToken`.
+
+## Row-level security
+
+`appv2.py` can pass a username to Power BI so row-level security (RLS) rules are applied. Create a role named **UserEmailRole** in your dataset and filter tables using `USERNAME()` or `USERPRINCIPALNAME()`. Publish the dataset and provide a `username` query parameter when requesting a token. If you need a different role name, set the `RLS_ROLE_NAME` environment variable.
 
 ## Embedding in WordPress
 

--- a/appv2.py
+++ b/appv2.py
@@ -12,6 +12,7 @@ CORS(app, origins=["https://work.hale.global", "https://haleglobal.com", "https:
 TENANT_ID = "3be3af3c-46a1-461d-93b1-44954da5e032"
 CLIENT_ID = "191260ff-ab3f-4d75-a211-780754200954"
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")  # Set this in your Render env vars
+RLS_ROLE_NAME = os.getenv("RLS_ROLE_NAME", "UserEmailRole")
 
 def is_valid_guid(value):
     return re.fullmatch(r'[a-fA-F0-9\-]{36}', value or '') is not None
@@ -76,7 +77,7 @@ def get_embed_token():
     if user_email:
         payload["identities"] = [{
             "username": user_email,
-            "roles": ["UserEmailRole"],
+            "roles": [RLS_ROLE_NAME],
             "datasets": [dataset_id]
         }]
 


### PR DESCRIPTION
## Summary
- describe optional `RLS_ROLE_NAME` variable in README
- instruct how to create dataset role for RLS
- use `RLS_ROLE_NAME` env var in appv2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68711f38fd68832f9354c87b6196968e