### PR TITLE
Add server URL override to embedScript_v2

### DIFF
--- a/static/embedScript_v2.js
+++ b/static/embedScript_v2.js
@@ -4,14 +4,18 @@
 
   sdkScript.onload = () => {
     const container = document.getElementById("reportContainer");
-    const configData = window.PowerBIEmbedConfig || {
-      reportId: container.dataset.reportId,
-      groupId: container.dataset.groupId,
-      datasetId: container.dataset.datasetId,
+    const globalCfg = window.PowerBIEmbedConfig || {};
+    const configData = {
+      reportId: globalCfg.reportId || container.dataset.reportId,
+      groupId: globalCfg.groupId || container.dataset.groupId,
+      datasetId: globalCfg.datasetId || container.dataset.datasetId,
     };
 
+    const serverUrl = (globalCfg.serverUrl || container.dataset.serverUrl ||
+      "https://powerbi-token-server.onrender.com").replace(/\/$/, "");
+
     const userEmail = window.loggedInEmail || container.dataset.username;
-    let url = `https://powerbi-token-server.onrender.com/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
+    let url = `${serverUrl}/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
     if (userEmail) {
       url += `&username=${encodeURIComponent(userEmail)}`;
     }


### PR DESCRIPTION
## Summary
- add support for `data-server-url` or `window.PowerBIEmbedConfig.serverUrl` in `embedScript_v2.js`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687121a43788832f8ec162de922f76d6