### PR TITLE
Improve debug logging for token errors

### DIFF
--- a/appv2.py
+++ b/appv2.py
@@ -84,10 +84,16 @@ def get_embed_token():
     response = requests.post(embed_url, headers=headers, json=payload)
 
     if response.status_code != 200:
-        print("Power BI API response error:", response.text)
+        print("\u274c Power BI API token error:")
+        print("Status code:", response.status_code)
+        print("Response text:", response.text)
+        print("Sent payload:", payload)
+
         return jsonify({
             "error": "Failed to generate embed token",
-            "details": response.text
+            "status_code": response.status_code,
+            "response": response.text,
+            "payload_used": payload
         }), 500
 
     token = response.json().get("token")

--- a/static/embedScript_v2.js
+++ b/static/embedScript_v2.js
@@ -15,9 +15,12 @@
       "https://powerbi-token-server.onrender.com").replace(/\/$/, "");
 
     const userEmail = window.loggedInEmail || container.dataset.username;
-console.log("🧪 userEmail passed to server:", userEmail);
-let url = `${serverUrl}/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
-
+    console.log("🧪 userEmail passed to server:", userEmail);
+    let url = `${serverUrl}/getEmbedToken?reportId=${configData.reportId}&groupId=${configData.groupId}&datasetId=${configData.datasetId}`;
+    if (userEmail) {
+      url += `&username=${encodeURIComponent(userEmail)}`;
+    }
+    console.log("🧪 requesting:", url);
 
     fetch(url)
       .then(res => res.json())


### PR DESCRIPTION
## Summary
- log detailed error info when Power BI token generation fails
- show username and request URL in embedScript_v2

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_687155f7d0d8832f8d21205b222cd1e4